### PR TITLE
build: Migrate to vcpkg and explicit CMake setup for CI/CD

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,30 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "build"
+
+[build]
+  # cmd is the build command triggered on change
+  cmd = "cmake --build build -j$(nproc)"
+  # bin is the path to the compiled binary (used by full_bin)
+  bin = "build/gbemu"
+  # full_bin is how you want to run the binary after a successful build
+  # Note: This will attempt to run the emulator. If you just want it to build, 
+  # you can set this to "true" or a no-op.
+  full_bin = "true"
+  delay = 500
+  exclude_dir = ["build", "vcpkg_installed", ".git", ".vscode"]
+  include_ext = ["cpp", "h", "hpp", "c", "txt", "json"]
+  stop_on_error = true
+  log = "air.log"
+
+[log]
+  time = false
+
+[color]
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[misc]
+  clean_on_exit = false

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+build/
+vcpkg_installed/
+.git/
+.vscode/
+out.txt
+*.excalidraw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install System Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential clang cmake curl zip unzip tar pkg-config autoconf autoconf-archive automake libtool libltdl-dev
+
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: ${{ github.workspace }}/vcpkg
+        vcpkgGitCommitId: 4b77da7fed37817f124936239197833469f1b9a8
+
+    - name: Configure CMake
+      run: |
+        export CC=clang
+        export CXX=clang++
+        cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    - name: Build
+      run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,70 +1,52 @@
-cmake_minimum_required (VERSION 3.17)
-set (CMAKE_CXX_STANDARD 20)
+cmake_minimum_required(VERSION 3.17)
 
 project(GBEmulator)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-list(APPEND CMAKE_PREFIX_PATH "/home/h9lopez/boost_1_81_0;/home/h9lopez/boost_1_81_0/stage/lib")
 
-set(Boost_USE_STATIC_LIBS   ON)
-FIND_PACKAGE(Boost 1.81.0 COMPONENTS log thread program_options REQUIRED)
-FIND_PACKAGE(SDL2 REQUIRED)
+# If compiling with Clang on a Linux system, linking libc++ might require specific flags
+# or cause issues if the dependencies (like Boost/SDL) were built with libstdc++.
+# In vcpkg, packages are built with the default system library (libstdc++ on Linux).
+# Therefore, forcing libc++ will lead to linker errors. Let's not force it.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+endif()
 
+find_package(Boost REQUIRED COMPONENTS log thread program_options)
+find_package(SDL2 CONFIG REQUIRED)
 
 # Set up the core library itself for use by both the main exec and the testing project
-file(GLOB CPP_SRC "GBEmulator/*/*/*.cpp" "GBEmulator/*/*.cpp" "GBEmulator/*.cpp")
-include_directories(GBEmulator)
-include_directories(GBEmulator/cpu/opcodes GBEmulator/cpu GBEmulator/display GBEmulator/ram
-    GBEmulator/registers GBEmulator/romloader GBEmulator/utils)
-include_directories(${Boost_INCLUDE_DIR})
-include_directories(${SDL2_INCLUDE_DIR})
+set(CPP_SRC
+    GBEmulator/cpu/CPUCore.cpp
+    GBEmulator/cpu/opcodes/OpcodeResultContext.cpp
+    GBEmulator/cpu/opcodes/gb_cpucore_cb_opcodes.cpp
+    GBEmulator/cpu/opcodes/gb_cpucore_opcode_utils.cpp
+    GBEmulator/cpu/opcodes/gb_cpucore_opcodes.cpp
+    GBEmulator/display/gb_ascii_screen.cpp
+    GBEmulator/display/gb_screen_api.cpp
+    GBEmulator/display/gb_screen_layer.cpp
+    GBEmulator/display/gb_screen_layerrenderer.cpp
+    GBEmulator/display/gb_sdl_screen.cpp
+    GBEmulator/ram/gb_ram.cpp
+    GBEmulator/registers/gb_regs.cpp
+    GBEmulator/romloader/gb_rom.cpp
+)
+
 add_library(gbemucore STATIC ${CPP_SRC})
-set_property(TARGET gbemucore PROPERTY CXX_STANDARD 20)
-target_link_libraries(gbemucore PRIVATE ${Boost_LIBRARIES})
-target_include_directories(gbemucore PRIVATE ${Boost_INCLUDE_DIRS})
-#target_compile_definitions(gbemucore PRIVATE BOOST_LOG_DYN_LINK)
-#target_link_libraries(gbemucore boost_log pthread)
+target_include_directories(gbemucore PUBLIC
+    GBEmulator
+    GBEmulator/cpu/opcodes
+    GBEmulator/cpu
+    GBEmulator/display
+    GBEmulator/ram
+    GBEmulator/registers
+    GBEmulator/romloader
+    GBEmulator/utils
+)
 
-
-# # thehandler tool
-# include_directories(thehandler)
-# file(GLOB HANDLER_CPP_SRC "thehandler/*.cpp")
-# add_executable(thehandler ${HANDLER_CPP_SRC})
-# target_include_directories(thehandler PRIVATE thehandler)
-# target_link_libraries(thehandler
-#     gbemucore
-#     ${Boost_LIBRARIES}
-#     ${Boost_LOG_LIBRARY}
-#     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-#     ${Boost_THREAD_LIBRARY}
-# )
-
-# Configure the testing target
-# enable_testing()
-# find_package(GTest REQUIRED)
-# include_directories(${GTEST_INCLUDE_DIRS})
-
-# set(TEST_CPP_SRC GBEmulator_Test/GBEmulator_Test.gen.cpp)
-# add_executable(gbemutest ${TEST_CPP_SRC})
-# target_include_directories(gbemutest PRIVATE GBEmulator_Test)
-# target_link_libraries(gbemutest 
-#     gbemucore
-#     ${GTEST_BOTH_LIBRARIES}
-#     ${Boost_LIBRARIES}
-#     ${Boost_LOG_LIBRARY}
-#     ${Boost_PROGRAM_OPTIONS_LIBRARY}
-#     ${Boost_THREAD_LIBRARY}
-#     )
-
-# TODO: Add workaround that has each GTest as its own test within ctest
-# add_test(AllTests gbemutest)
+target_link_libraries(gbemucore PUBLIC Boost::log Boost::thread Boost::program_options SDL2::SDL2)
 
 # Create the actual core runnable
 add_executable(gbemu GBEmulator/primary_loop.cpp)
-target_include_directories(gbemu PRIVATE ${Boost_INCLUDE_DIRS})
-#set_property(TARGET gbemu PROPERTY CXX_STANDARD 20)
-target_link_libraries(gbemu PRIVATE 
-                            gbemucore
-                            ${Boost_LIBRARIES}
-                            SDL2::SDL2main SDL2::SDL2-static)
-#target_compile_definitions(gbemu PRIVATE BOOST_LOG_DYN_LINK)
+target_link_libraries(gbemu PRIVATE gbemucore)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,9 @@
 FROM cosmtrek/air:latest AS air-builder
 
-FROM ubuntu:latest
+# Use the official Microsoft C++ Dev Container image
+FROM mcr.microsoft.com/devcontainers/cpp:latest
 
-# Set noninteractive installation to avoid tzdata prompts
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install System Dependencies required for vcpkg, Clang, and CMake
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    clang \
-    cmake \
-    curl \
-    zip \
-    unzip \
-    tar \
-    pkg-config \
-    autoconf \
-    autoconf-archive \
-    automake \
-    libtool \
-    libltdl-dev \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Setup vcpkg globally
-RUN git clone https://github.com/microsoft/vcpkg.git /vcpkg && \
-    /vcpkg/bootstrap-vcpkg.sh
-
-# Install air for hot-reloading using multi-stage copy (no curl/sh required)
+# Install air for hot-reloading using multi-stage copy
 COPY --from=air-builder /go/bin/air /usr/local/bin/air
 
 # Set environment variables for Clang compiler
@@ -36,10 +12,3 @@ ENV CXX=clang++
 
 # Create a working directory
 WORKDIR /app
-
-# The remaining build steps will typically be run manually during local development
-# Example usage:
-# docker build -t gbemulator-dev .
-# docker run -it -v $(pwd):/app gbemulator-dev
-# > cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake
-# > cmake --build build --config Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:latest
+
+# Set noninteractive installation to avoid tzdata prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install System Dependencies required for vcpkg, Clang, and CMake
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    clang \
+    cmake \
+    curl \
+    zip \
+    unzip \
+    tar \
+    pkg-config \
+    autoconf \
+    autoconf-archive \
+    automake \
+    libtool \
+    libltdl-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup vcpkg globally
+RUN git clone https://github.com/microsoft/vcpkg.git /vcpkg && \
+    /vcpkg/bootstrap-vcpkg.sh
+
+# Set environment variables for Clang compiler
+ENV CC=clang
+ENV CXX=clang++
+
+# Create a working directory
+WORKDIR /app
+
+# The remaining build steps will typically be run manually during local development
+# Example usage:
+# docker build -t gbemulator-dev .
+# docker run -it -v $(pwd):/app gbemulator-dev
+# > cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=/vcpkg/scripts/buildsystems/vcpkg.cmake
+# > cmake --build build --config Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM cosmtrek/air:latest AS air-builder
+
 FROM ubuntu:latest
 
 # Set noninteractive installation to avoid tzdata prompts
@@ -25,8 +27,8 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/microsoft/vcpkg.git /vcpkg && \
     /vcpkg/bootstrap-vcpkg.sh
 
-# Install air for hot-reloading (standard in this workspace)
-RUN curl -sSfL https://raw.githubusercontent.com/air-verse/air/master/install.sh | sh -s -- -b /usr/local/bin
+# Install air for hot-reloading using multi-stage copy (no curl/sh required)
+COPY --from=air-builder /go/bin/air /usr/local/bin/air
 
 # Set environment variables for Clang compiler
 ENV CC=clang

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apt-get update && apt-get install -y \
 RUN git clone https://github.com/microsoft/vcpkg.git /vcpkg && \
     /vcpkg/bootstrap-vcpkg.sh
 
+# Install air for hot-reloading (standard in this workspace)
+RUN curl -sSfL https://raw.githubusercontent.com/air-verse/air/master/install.sh | sh -s -- -b /usr/local/bin
+
 # Set environment variables for Clang compiler
 ENV CC=clang
 ENV CXX=clang++

--- a/GBEmulator/display/gb_screen_api.h
+++ b/GBEmulator/display/gb_screen_api.h
@@ -7,6 +7,7 @@
 #include <ram/gb_ram.h>
 #include <utils/addressrange.h>
 #include <SDL2/SDL_rect.h>
+#include <bitset>
 
 namespace GBScreenAPI {
 

--- a/GBEmulator/display/gb_screen_layer.cpp
+++ b/GBEmulator/display/gb_screen_layer.cpp
@@ -74,7 +74,7 @@ void Layer::updateSourceRegionInfo(const GBScreenAPI::TileDataRegionInfo& info)
         auto tileNum = d_ram->readByte(i);
         auto tile = (d_layoutTable[x][y]->tile) ? d_layoutTable[x][y]->tile : new DisplayTile();
         
-        tile->tileReferenceNum = tileNum;
+        tile->referenceNum = tileNum;
         if (d_dataRegionInfo.addressingMode == GBScreenAPI::TileDataAddressingMode::SIGNED_MODE)
         {
             tile->sourceRange.start = info.ingress + (static_cast<int>(tileNum) * 16);

--- a/GBEmulator/display/gb_screen_layerrenderer.cpp
+++ b/GBEmulator/display/gb_screen_layerrenderer.cpp
@@ -5,9 +5,17 @@ LayerRenderer::LayerRenderer(std::shared_ptr<Layer> layer, std::shared_ptr<SDL_R
     : d_layer(layer), d_sdlRenderer(renderObj)
 {
     // Iterate through the existing layout format and create SDL_Texture 
-    for (auto it = d_layer->layoutGridBegin(); it != d_layer->layoutGridEnd(); it++)
+    for (auto colIt = d_layer->layoutGridBegin(); colIt != d_layer->layoutGridEnd(); colIt++)
     {
-        it->tile->texture = SDL_CreateTexture(d_sdlRenderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_TARGET, GB_TILE_PIXEL_WIDTH, GB_TILE_PIXEL_HEIGHT);
+        for (auto it = colIt->begin(); it != colIt->end(); it++)
+        {
+            (*it)->tile->texture = SDL_CreateTexture(d_sdlRenderer.get(), SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_TARGET, GB_TILE_PIXEL_WIDTH, GB_TILE_PIXEL_HEIGHT);
+        }
     }
 }
 
+LayerRenderer::LayerRenderer()
+{}
+
+LayerRenderer::~LayerRenderer()
+{}

--- a/GBEmulator/display/gb_sdl_screen.h
+++ b/GBEmulator/display/gb_sdl_screen.h
@@ -16,7 +16,7 @@
 #define GB_TILE_PIXEL_WIDTH 8
 #define GB_TILE_PIXEL_HEIGHT 8
 
-struct SDL_Color_Comp : public std::binary_function<SDL_Color, SDL_Color, bool> {
+struct SDL_Color_Comp {
     bool operator()(const SDL_Color& a, const SDL_Color& b) const { 
         return std::tie(a.r, a.g, a.b, a.a) < std::tie(b.r, b.g, b.b, b.a);
     }

--- a/GBEmulator/primary_loop.cpp
+++ b/GBEmulator/primary_loop.cpp
@@ -51,27 +51,38 @@ SDL_Window* localSDLInit()
 
 int main(int argc, char *argv[])
 {
-	static std::string bootROM = "/home/h9lopez/Code/GBEmulator/GBEmulator_Test/ASMTest/simpleLoadTest.gb";
-	//static std::string bootROM = "/Users/hlopez34/Code/GBEmulator/GBEmulator_Test/ASMTest/DMG_ROM.bin";
+	static std::string bootROM = "";
 	static std::string memDumpPath = "";
 
 	// Load command line args
 	boost::program_options::options_description description("Allowed options");
 	description.add_options()
+				("help", "produce help message")
 				("romPath", boost::program_options::value<std::string>(), "Set startup ROM path")
 				("memDumpPath", boost::program_options::value<std::string>(), "If set, will dump memory state post-execution of ROM completion.")
 	;
 
 	boost::program_options::variables_map vm;
-	boost::program_options::store(boost::program_options::parse_command_line(argc,argv,description), vm);
-	boost::program_options::notify(vm);
+	try {
+		boost::program_options::store(boost::program_options::parse_command_line(argc, argv, description), vm);
+		boost::program_options::notify(vm);
+	} catch (const boost::program_options::error& e) {
+		std::cerr << "Error parsing command line arguments: " << e.what() << "\n";
+		std::cout << description << "\n";
+		return 1;
+	}
+
+	if (vm.count("help")) {
+		std::cout << description << "\n";
+		return 0;
+	}
 
 	if (vm.count(ARG_ROM_PATH)) {
 		bootROM = vm[ARG_ROM_PATH].as< string >();
 	}
-	else
+	else if (bootROM.empty())
 	{
-		BOOST_LOG_TRIVIAL(error) << "No boot rom path provided";
+		BOOST_LOG_TRIVIAL(error) << "No boot rom path provided. Use --romPath <path> to specify one.";
 		return -1;
 	}
 	if (vm.count(ARG_MEM_DUMP_PATH)) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,3 @@ services:
     stdin_open: true
     working_dir: /app
     command: air
-    develop:
-      watch:
-        - path: .
-          action: sync
-          target: /app
-          ignore:
-            - build/
-            - vcpkg_installed/
-            - .git/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  dev:
+    build: .
+    volumes:
+      - .:/app
+    environment:
+      - CC=clang
+      - CXX=clang++
+    # Keeps the container running so you can exec into it
+    tty: true
+    stdin_open: true
+    working_dir: /app
+    command: air
+    develop:
+      watch:
+        - path: .
+          action: sync
+          target: /app
+          ignore:
+            - build/
+            - vcpkg_installed/
+            - .git/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
     tty: true
     stdin_open: true
     working_dir: /app
-    command: air
+    command: bash -c "cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=/usr/local/vcpkg/scripts/buildsystems/vcpkg.cmake && air"

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "baseline": "4b77da7fed37817f124936239197833469f1b9a8",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "gbemulator",
+  "version-string": "1.0.0",
+  "dependencies": [
+    "boost-log",
+    "boost-thread",
+    "boost-program-options",
+    "boost-signals2",
+    "sdl2"
+  ]
+}


### PR DESCRIPTION
Migrated the project to use vcpkg for dependency management, ensuring easier and more consistent builds locally and in CI/CD. Hardcoded paths to Boost and SDL2 in `CMakeLists.txt` have been removed, replacing `GLOB` with explicit source lists. Additionally, a new `.github/workflows/build.yml` file has been added to automatically build the project via GitHub Actions on push and pull requests to main, using `clang` and `vcpkg`. Minor missing headers (`<bitset>`) and syntax incompatibilities flagged by Clang 18 were also addressed.

---
*PR created automatically by Jules for task [10416214281812693563](https://jules.google.com/task/10416214281812693563) started by @h9lopez*